### PR TITLE
Implement Keep-style note editor animations

### DIFF
--- a/github/index.html
+++ b/github/index.html
@@ -165,6 +165,64 @@
         #search-modal {
             padding-top: calc(env(safe-area-inset-top) + 2rem);
         }
+
+        :root {
+            --note-transition-duration: 220ms;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            :root {
+                --note-transition-duration: 1ms;
+            }
+        }
+
+        #note-transition-backdrop {
+            background: rgba(15, 23, 42, 0.2);
+            backdrop-filter: blur(6px);
+            pointer-events: none;
+        }
+
+        .dark #note-transition-backdrop {
+            background: rgba(15, 23, 42, 0.35);
+        }
+
+        ::view-transition-old(note-card-hero),
+        ::view-transition-new(note-card-hero) {
+            animation-duration: var(--note-transition-duration);
+            animation-timing-function: ease-in-out;
+            transform-origin: center center;
+            animation-fill-mode: both;
+        }
+
+        ::view-transition-old(note-card-hero) {
+            animation-name: note-card-hero-old;
+        }
+
+        ::view-transition-new(note-card-hero) {
+            animation-name: note-card-hero-new;
+        }
+
+        @keyframes note-card-hero-old {
+            from {
+                opacity: 1;
+                transform: scale(1);
+            }
+            to {
+                opacity: 0;
+                transform: scale(0.97);
+            }
+        }
+
+        @keyframes note-card-hero-new {
+            from {
+                opacity: 0;
+                transform: scale(1.02);
+            }
+            to {
+                opacity: 1;
+                transform: scale(1);
+            }
+        }
     </style>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
@@ -312,11 +370,15 @@
         <h1 class="text-xl font-bold ml-4">Заметка</h1>
     </header>
     <main class="flex-grow">
-        <textarea id="note-editor-textarea" class="w-full h-full p-4 bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white outline-none resize-none text-lg" placeholder="Введите текст..."></textarea>
+        <div id="note-editor-hero" class="h-full">
+            <textarea id="note-editor-textarea" class="w-full h-full p-4 bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white outline-none resize-none text-lg" placeholder="Введите текст..."></textarea>
+        </div>
     </main>
 </div>
     </div>
-    
+
+    <div id="note-transition-backdrop" class="fixed inset-0 opacity-0 hidden z-30"></div>
+
     <!-- Floating buttons -->
     <button id="add-btn" class="fixed bottom-20 md:bottom-6 right-6 bg-blue-600 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-blue-700 transition-transform transform hover:scale-110 z-20">
         <svg class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
@@ -424,6 +486,7 @@
                 searchResults: document.getElementById('search-results'),
                 noSearchResults: document.getElementById('no-search-results'),
                 closeSearchBtn: document.getElementById('close-search-btn'),
+                noteTransitionBackdrop: document.getElementById('note-transition-backdrop'),
                 importFileInput: document.getElementById('import-file-input'),
                 notification: document.getElementById('notification'),
                 notificationText: document.getElementById('notification-text'),
@@ -459,6 +522,7 @@
                     page: document.getElementById('note-editor-page'),
                     backBtn: document.getElementById('note-editor-back-btn'),
                     textarea: document.getElementById('note-editor-textarea'),
+                    hero: document.getElementById('note-editor-hero'),
                 }
             };
 
@@ -487,6 +551,10 @@
 
             // Global UI state
             let isSearchModalOpen = false;
+
+            const prefersReducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+            const noteViewTransitionName = 'note-card-hero';
+            let noteBackdropAnimation = null;
 
             // --- Formatters ---
             const currencyFormatter = new Intl.NumberFormat('ru-RU', { style: 'currency', currency: 'RUB', minimumFractionDigits: 0 });
@@ -573,8 +641,62 @@
                 else if (pageId === 'notes') renderNotes();
                 else if (pageId === 'note-editor') setupNoteEditor(options.noteId);
                 else if (pageId === 'settings') renderDataManagementUI();
-                
+
                 toggleSidebar(false);
+            };
+
+            const canUseViewTransitions = () => typeof document.startViewTransition === 'function';
+
+            const getNoteTransitionDuration = () => prefersReducedMotionQuery.matches ? 1 : 250;
+
+            const isElementVisible = (element) => !!(element && element.isConnected && element.getClientRects().length);
+
+            const animateNoteBackdrop = (show) => {
+                const backdrop = ui.noteTransitionBackdrop;
+                if (!backdrop) return null;
+                if (!show && backdrop.classList.contains('hidden')) {
+                    backdrop.style.opacity = '0';
+                    return null;
+                }
+                noteBackdropAnimation?.cancel();
+                if (show) {
+                    backdrop.classList.remove('hidden');
+                }
+                const duration = getNoteTransitionDuration();
+                backdrop.style.opacity = show ? '0' : '1';
+                noteBackdropAnimation = backdrop.animate(
+                    [
+                        { opacity: show ? 0 : 1 },
+                        { opacity: show ? 1 : 0 }
+                    ],
+                    {
+                        duration,
+                        easing: 'ease-in-out',
+                        fill: 'forwards'
+                    }
+                );
+                if (duration === 1) {
+                    noteBackdropAnimation.finish();
+                }
+                noteBackdropAnimation.finished
+                    .then(() => {
+                        if (show) {
+                            backdrop.style.opacity = '1';
+                        } else {
+                            backdrop.style.opacity = '0';
+                            backdrop.classList.add('hidden');
+                        }
+                    })
+                    .catch(() => {})
+                    .finally(() => {
+                        noteBackdropAnimation = null;
+                    });
+                return noteBackdropAnimation;
+            };
+
+            const getNoteCardElement = (noteId) => {
+                if (noteId === null || typeof noteId === 'undefined') return null;
+                return ui.notesPage.listContainer.querySelector(`.note-card[data-note-id="${noteId}"]`);
             };
 
             const createTransactionElement = (tx) => {
@@ -907,6 +1029,256 @@
                 });
             }
 
+            const parseNoteId = (noteId) => {
+                if (noteId === null || typeof noteId === 'undefined' || Number.isNaN(noteId)) return null;
+                if (typeof noteId === 'number') return noteId;
+                const parsed = parseInt(noteId, 10);
+                return Number.isNaN(parsed) ? null : parsed;
+            };
+
+            const openNoteEditorLikeKeep = (noteId = null) => {
+                const targetId = parseNoteId(noteId);
+                const hero = ui.noteEditorPage.hero;
+                if (!hero) {
+                    showPage('note-editor', { noteId: targetId });
+                    return;
+                }
+
+                const card = getNoteCardElement(targetId);
+
+                if (canUseViewTransitions() && isElementVisible(card)) {
+                    try {
+                        hero.style.viewTransitionName = noteViewTransitionName;
+                        card.style.viewTransitionName = noteViewTransitionName;
+                        animateNoteBackdrop(true);
+                        const transition = document.startViewTransition(() => {
+                            showPage('note-editor', { noteId: targetId });
+                        });
+                        transition.finished.finally(() => {
+                            animateNoteBackdrop(false);
+                            card?.style.removeProperty('viewTransitionName');
+                            hero.style.removeProperty('viewTransitionName');
+                        });
+                        return;
+                    } catch (error) {
+                        card?.style.removeProperty('viewTransitionName');
+                        hero.style.removeProperty('viewTransitionName');
+                        animateNoteBackdrop(false);
+                    }
+                }
+
+                const duration = getNoteTransitionDuration();
+                if (!card || !isElementVisible(card) || duration === 1) {
+                    showPage('note-editor', { noteId: targetId });
+                    return;
+                }
+
+                const editorPage = ui.noteEditorPage.page;
+                const wasHidden = editorPage.classList.contains('hidden');
+                const previousStyles = {
+                    visibility: editorPage.style.visibility,
+                    position: editorPage.style.position,
+                    inset: editorPage.style.inset
+                };
+
+                if (wasHidden) {
+                    editorPage.classList.remove('hidden');
+                    editorPage.style.visibility = 'hidden';
+                    editorPage.style.position = 'fixed';
+                    editorPage.style.inset = '0';
+                }
+
+                const heroRect = hero.getBoundingClientRect();
+
+                if (wasHidden) {
+                    editorPage.classList.add('hidden');
+                    editorPage.style.visibility = previousStyles.visibility;
+                    editorPage.style.position = previousStyles.position;
+                    editorPage.style.inset = previousStyles.inset;
+                }
+
+                const cardRect = card.getBoundingClientRect();
+
+                if (!heroRect.width || !heroRect.height || !cardRect.width || !cardRect.height) {
+                    showPage('note-editor', { noteId: targetId });
+                    return;
+                }
+
+                const cardClone = card.cloneNode(true);
+                const computedCardStyles = window.getComputedStyle(card);
+                cardClone.style.position = 'fixed';
+                cardClone.style.top = `${cardRect.top}px`;
+                cardClone.style.left = `${cardRect.left}px`;
+                cardClone.style.width = `${cardRect.width}px`;
+                cardClone.style.height = `${cardRect.height}px`;
+                cardClone.style.margin = '0';
+                cardClone.style.zIndex = '1000';
+                cardClone.style.transformOrigin = 'top left';
+                cardClone.style.borderRadius = computedCardStyles.borderRadius;
+                cardClone.style.boxShadow = computedCardStyles.boxShadow;
+                document.body.appendChild(cardClone);
+                card.style.visibility = 'hidden';
+
+                animateNoteBackdrop(true);
+
+                const translateX = heroRect.left - cardRect.left;
+                const translateY = heroRect.top - cardRect.top;
+                const scaleX = heroRect.width / cardRect.width;
+                const scaleY = heroRect.height / cardRect.height;
+
+                const animation = cardClone.animate(
+                    [
+                        { transform: 'translate(0px, 0px) scale(1, 1)', opacity: 1 },
+                        { transform: `translate(${translateX}px, ${translateY}px) scale(${scaleX}, ${scaleY})`, opacity: 1 }
+                    ],
+                    {
+                        duration,
+                        easing: 'ease-in-out',
+                        fill: 'forwards'
+                    }
+                );
+
+                if (duration === 1) {
+                    animation.finish();
+                }
+
+                animation.finished
+                    .catch(() => {})
+                    .finally(() => {
+                        showPage('note-editor', { noteId: targetId });
+                        card.style.visibility = '';
+                        cardClone.remove();
+                        animateNoteBackdrop(false);
+                    });
+            };
+
+            const closeEditorLikeKeep = () => {
+                const hero = ui.noteEditorPage.hero;
+                const targetId = currentNoteId;
+                if (!hero) {
+                    showPage('notes');
+                    currentNoteId = null;
+                    return;
+                }
+
+                if (canUseViewTransitions()) {
+                    try {
+                        hero.style.viewTransitionName = noteViewTransitionName;
+                        animateNoteBackdrop(true);
+                        const transition = document.startViewTransition(() => {
+                            showPage('notes');
+                            const card = getNoteCardElement(targetId);
+                            if (card) {
+                                card.style.viewTransitionName = noteViewTransitionName;
+                            }
+                        });
+                        transition.finished.finally(() => {
+                            animateNoteBackdrop(false);
+                            hero.style.removeProperty('viewTransitionName');
+                            const card = getNoteCardElement(targetId);
+                            card?.style.removeProperty('viewTransitionName');
+                            currentNoteId = null;
+                        });
+                        return;
+                    } catch (error) {
+                        hero.style.removeProperty('viewTransitionName');
+                        const card = getNoteCardElement(targetId);
+                        card?.style.removeProperty('viewTransitionName');
+                        animateNoteBackdrop(false);
+                    }
+                }
+
+                const duration = getNoteTransitionDuration();
+
+                if (duration === 1 || targetId === null) {
+                    showPage('notes');
+                    currentNoteId = null;
+                    return;
+                }
+
+                renderNotes(ui.notesPage.searchInput.value || '');
+
+                const notesPage = ui.notesPage.page;
+                const wasHidden = notesPage.classList.contains('hidden');
+                const previousStyles = {
+                    visibility: notesPage.style.visibility,
+                    position: notesPage.style.position,
+                    inset: notesPage.style.inset
+                };
+
+                if (wasHidden) {
+                    notesPage.classList.remove('hidden');
+                    notesPage.style.visibility = 'hidden';
+                    notesPage.style.position = 'fixed';
+                    notesPage.style.inset = '0';
+                }
+
+                const card = getNoteCardElement(targetId);
+                const cardRect = card ? card.getBoundingClientRect() : null;
+
+                if (wasHidden) {
+                    notesPage.classList.add('hidden');
+                    notesPage.style.visibility = previousStyles.visibility;
+                    notesPage.style.position = previousStyles.position;
+                    notesPage.style.inset = previousStyles.inset;
+                }
+
+                if (!cardRect || !cardRect.width || !cardRect.height) {
+                    showPage('notes');
+                    currentNoteId = null;
+                    return;
+                }
+
+                const heroRect = hero.getBoundingClientRect();
+                const heroClone = hero.cloneNode(true);
+                heroClone.style.position = 'fixed';
+                heroClone.style.top = `${heroRect.top}px`;
+                heroClone.style.left = `${heroRect.left}px`;
+                heroClone.style.width = `${heroRect.width}px`;
+                heroClone.style.height = `${heroRect.height}px`;
+                heroClone.style.margin = '0';
+                heroClone.style.zIndex = '1000';
+                heroClone.style.transformOrigin = 'top left';
+                document.body.appendChild(heroClone);
+                hero.style.visibility = 'hidden';
+
+                animateNoteBackdrop(true);
+
+                const translateX = cardRect.left - heroRect.left;
+                const translateY = cardRect.top - heroRect.top;
+                const scaleX = cardRect.width / heroRect.width;
+                const scaleY = cardRect.height / heroRect.height;
+
+                const animation = heroClone.animate(
+                    [
+                        { transform: 'translate(0px, 0px) scale(1, 1)', opacity: 1 },
+                        { transform: `translate(${translateX}px, ${translateY}px) scale(${scaleX}, ${scaleY})`, opacity: 1 }
+                    ],
+                    {
+                        duration,
+                        easing: 'ease-in-out',
+                        fill: 'forwards'
+                    }
+                );
+
+                if (duration === 1) {
+                    animation.finish();
+                }
+
+                animation.finished
+                    .catch(() => {})
+                    .finally(() => {
+                        showPage('notes');
+                        hero.style.visibility = '';
+                        heroClone.remove();
+                        animateNoteBackdrop(false);
+                        currentNoteId = null;
+                    });
+            };
+
+            window.openNoteEditorLikeKeep = openNoteEditorLikeKeep;
+            window.closeEditorLikeKeep = closeEditorLikeKeep;
+
             const saveCurrentNote = () => {
                 const content = ui.noteEditorPage.textarea.value.trim();
                 if (content) {
@@ -914,13 +1286,16 @@
                         const index = notes.findIndex(n => n.id === currentNoteId);
                         if (index > -1) notes[index].content = content;
                     } else {
-                        notes.push({ id: Date.now(), content: content });
+                        const newId = Date.now();
+                        notes.push({ id: newId, content: content });
+                        currentNoteId = newId;
                     }
                 } else if (currentNoteId !== null) {
                     notes = notes.filter(n => n.id !== currentNoteId);
+                    currentNoteId = null;
                 }
                 saveData();
-                showPage('notes');
+                closeEditorLikeKeep();
             }
 
             function enterNotesSelectionMode(noteCard) {
@@ -1349,7 +1724,7 @@
                         }
                         showTransactionModal(displayFilter);
                     } else if (activePageId === 'notes-page') {
-                        showPage('note-editor', { noteId: null });
+                        openNoteEditorLikeKeep(null);
                     }
                 };
                 
@@ -1426,7 +1801,7 @@
                             updateSelectionHeader();
                         }
                     } else {
-                        showPage('note-editor', { noteId: parseInt(targetCard.dataset.noteId) });
+                        openNoteEditorLikeKeep(parseInt(targetCard.dataset.noteId));
                     }
                 });
 


### PR DESCRIPTION
## Summary
- add view-transition styling and reduced-motion tuning for the note editor hero
- wrap the note editor in a hero container and add a backdrop overlay element
- implement open/close helpers that animate with the View Transitions API and Web Animations fallback, wiring them into existing note actions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a84dce288322bb89d71eb05957fc